### PR TITLE
Add parallax stars, harvest effects, and UI polish

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,13 +26,19 @@ const CONTRACTS=[
 
 function SectionTitle({children}){ return <div className="section-title"><div className="dot"></div><h2>{children}</h2></div>; }
 function Pill({children}){ return <div className="pill">{children}</div>; }
-function ProgressBar({value}){ const v=Math.max(0,Math.min(100,value||0)); return <div className="progress"><span style={{width:v+"%"}}/></div>; }
+function ProgressBar({value}){ const v=Math.max(0,Math.min(100,value||0)); const striped=v>0&&v<100; return <div className="progress"><span className={`fill${striped?" striped":""}`} style={{width:v+"%"}}/></div>; }
 
 function App(){
   const [energy,setEnergy]=useState(0),[clickPower,setClickPower]=useState(1),[autoPerSec,setAutoPerSec]=useState(0),[mult,setMult]=useState(1),[owned,setOwned]=useState({}),[rp,setRp]=useState(0),[prestiges,setPrestiges]=useState(0);
   const [research,setResearch]=useState({tapBoost:0,autoBoost:0,multBoost:0});
   const [completedContracts,setCompletedContracts]=useState([]);
+  const [displayEnergy,setDisplayEnergy]=useState(0);
   const holdRef = useRef(null);
+  const animRef = useRef(null);
+  const btnRef = useRef(null);
+  const badgeRefs = useRef({});
+  const particleLayerRef = useRef(null);
+  const lastParticleRef = useRef(0);
 
   // self-tests (console)
   useEffect(()=>{try{
@@ -52,6 +58,25 @@ function App(){
     }catch(e){} } },[]);
   useEffect(()=>{ localStorage.setItem("area52-pwa-save-v2", JSON.stringify({energy,clickPower,autoPerSec,mult,owned,rp,prestiges,research,completedContracts})); },
     [energy,clickPower,autoPerSec,mult,owned,rp,prestiges,research,completedContracts]);
+  useEffect(()=>{ particleLayerRef.current=document.getElementById('particles'); },[]);
+  useEffect(()=>{
+    const from=displayEnergy;
+    const to=energy;
+    if(from===to) return;
+    cancelAnimationFrame(animRef.current);
+    const diff=to-from;
+    if(Math.abs(diff)<5){ setDisplayEnergy(to); return; }
+    const duration=Math.min(240,Math.max(120,Math.abs(diff)));
+    const start=performance.now();
+    const step=(now)=>{
+      const p=Math.min(1,(now-start)/duration);
+      const eased=1-Math.pow(1-p,3);
+      setDisplayEnergy(from+diff*eased);
+      if(p<1) animRef.current=requestAnimationFrame(step);
+    };
+    animRef.current=requestAnimationFrame(step);
+  },[energy]);
+  useEffect(()=>()=>cancelAnimationFrame(animRef.current),[]);
 
   // passive income
   useEffect(()=>{ const t=setInterval(()=>{ setEnergy(e=>e+Math.floor(autoPerSec*(1+research.autoBoost)*(1+rp*0.02+research.multBoost+(mult-1)))) },1000);
@@ -59,11 +84,28 @@ function App(){
   },[autoPerSec,mult,rp,research]);
 
   const totalMult=useMemo(()=>1+rp*0.02+research.multBoost+(mult-1),[rp,mult,research]);
-  const handleTap=()=>setEnergy(e=>e+Math.floor(clickPower*(1+research.tapBoost)*totalMult));
+  const spawnParticles=()=>{
+    const layer=particleLayerRef.current,btn=btnRef.current; if(!layer||!btn) return;
+    const now=performance.now(); if(now-lastParticleRef.current<100) return; lastParticleRef.current=now;
+    const rect=btn.getBoundingClientRect(); const cx=rect.left+rect.width/2, cy=rect.top+rect.height/2;
+    const count=6+Math.floor(Math.random()*5);
+    for(let i=0;i<count;i++){
+      const p=document.createElement('span'); p.className='particle';
+      p.style.left=(cx+(Math.random()*40-20))+'px';
+      p.style.top=(cy+(Math.random()*10-5))+'px';
+      const ang=Math.random()*Math.PI-Math.PI/2,dist=20+Math.random()*40;
+      p.style.setProperty('--tx',`${Math.cos(ang)*dist}px`);
+      p.style.setProperty('--ty',`${Math.sin(ang)*dist-60}px`);
+      p.style.setProperty('--dur',`${400+Math.random()*300}ms`);
+      layer.appendChild(p);
+      p.addEventListener('animationend',()=>p.remove(),{once:true});
+    }
+  };
+  const handleTap=()=>{ setEnergy(e=>e+Math.floor(clickPower*(1+research.tapBoost)*totalMult)); spawnParticles(); };
 
   // hold-to-tap
-  const startHold=(ev)=>{ev?.preventDefault?.(); if(holdRef.current) return; holdRef.current=setInterval(()=>handleTap(),HOLD_INTERVAL_MS)};
-  const stopHold=()=>{if(holdRef.current){clearInterval(holdRef.current); holdRef.current=null;}};
+  const startHold=(ev)=>{ev?.preventDefault?.(); btnRef.current?.classList.add('is-holding'); if(holdRef.current) return; holdRef.current=setInterval(()=>handleTap(),HOLD_INTERVAL_MS)};
+  const stopHold=()=>{btnRef.current?.classList.remove('is-holding'); if(holdRef.current){clearInterval(holdRef.current); holdRef.current=null;}};
 
   const getOwned=(id)=>owned[id]||0;
   const costOf=(u)=>computeCost(u.baseCost,u.costScale,getOwned(u.id));
@@ -72,6 +114,8 @@ function App(){
     if(u.type==="click")setClickPower(v=>v+u.amountPerBuy);
     if(u.type==="auto")setAutoPerSec(v=>v+u.amountPerBuy);
     if(u.type==="mult")setMult(v=>v+u.amountPerBuy);
+    const b=badgeRefs.current[u.id];
+    if(b){ b.classList.add('flash'); b.addEventListener('animationend',()=>b.classList.remove('flash'),{once:true}); }
   };
 
   const canPrestige=energy>=50000;
@@ -95,13 +139,13 @@ function App(){
       </p>
 
       <div style={{marginTop:18, display:"flex", flexWrap:"wrap", gap:12, justifyContent:"center"}}>
-        <button className="btn"
+        <button id="harvest-btn" ref={btnRef} className="btn"
           onClick={handleTap}
           onMouseDown={startHold} onMouseUp={stopHold} onMouseLeave={stopHold}
           onTouchStart={startHold} onTouchEnd={stopHold}
         >👽 Harvest Energy</button>
 
-        <Pill>Energy: <span style={{color:ACCENT, marginLeft:8}}>{fmt(energy)}</span></Pill>
+        <Pill>Energy: <span style={{color:ACCENT, marginLeft:8}}>{fmt(Math.floor(displayEnergy))}</span></Pill>
         <Pill>Click Power: <span style={{color:ACCENT, marginLeft:8}}>{fmt(clickPower)}×</span></Pill>
         <Pill>Auto/sec: <span style={{color:ACCENT, marginLeft:8}}>{fmt(Math.floor(autoPerSec*totalMult))}</span></Pill>
         <Pill>Global Mult: <span style={{color:ACCENT, marginLeft:8}}>{totalMult.toFixed(2)}×</span></Pill>
@@ -110,23 +154,23 @@ function App(){
       {/* Upgrades close to main button */}
       <SectionTitle>UPGRADES</SectionTitle>
       <div className="grid cols-3">
-        {UPGRADES.map(u=>(
-          <div key={u.id} className="card">
+        {UPGRADES.map(u=>{ const cost=costOf(u); const can=energy>=cost; return (
+          <div key={u.id} className={`card${can?"":" disabled"}`}>
             <div className="content">
               <div style={{display:"flex", justifyContent:"space-between", alignItems:"flex-start"}}>
                 <div>
                   <div style={{letterSpacing:".25em", textTransform:"uppercase", fontSize:14}}>{u.title}</div>
                   <div style={{opacity:.7, fontSize:12}}>{u.subtitle}</div>
                 </div>
-                <span className="badge">Owned: {getOwned(u.id)}</span>
+                <span ref={el=>badgeRefs.current[u.id]=el} className="badge">Owned: {getOwned(u.id)}</span>
               </div>
               <div style={{display:"flex", justifyContent:"space-between", alignItems:"center", marginTop:12}}>
-                <div style={{opacity:.8, fontSize:14}}>Cost: <span style={{color:ACCENT}}>{fmt(costOf(u))}</span></div>
-                <button className="btn btn-outline" disabled={energy<costOf(u)} onClick={()=>buy(u)}>Add — {fmt(costOf(u))}</button>
+                <div style={{opacity:.8, fontSize:14}}>Cost: <span style={{color:ACCENT}}>{fmt(cost)}</span></div>
+                <button className="btn btn-outline" disabled={!can} onClick={()=>buy(u)}>Add — {fmt(cost)}</button>
               </div>
             </div>
           </div>
-        ))}
+        );})}
       </div>
 
       {/* Prestige */}
@@ -139,7 +183,7 @@ function App(){
           </div>
           <div style={{marginTop:8, opacity:.8, fontSize:14}}>Reset and trade built-up Energy for <b>Research Points</b> that permanently boost all gains.</div>
           <div style={{marginTop:12}}><ProgressBar value={progressToPrestige} /></div>
-          <div style={{marginTop:6, opacity:.7, fontSize:12}}>Next RP at <span style={{color:ACCENT}}>50,000</span> energy. Current: {fmt(energy)}</div>
+          <div style={{marginTop:6, opacity:.7, fontSize:12}}>Next RP at <span style={{color:ACCENT}}>50,000</span> energy. Current: {fmt(Math.floor(displayEnergy))}</div>
           <div style={{marginTop:12}}>
             <button className="btn btn-outline" disabled={!canPrestige} onClick={doPrestige}>Declassify now</button>
           </div>

--- a/index.html
+++ b/index.html
@@ -28,16 +28,24 @@
         linear-gradient(180deg, var(--bg1), var(--bg0));
       animation: gradientShift 30s ease-in-out infinite;
     }
-    @keyframes starMove {
-      from { background-position: 0 0; }
-      to { background-position: -1000px 1000px; }
+    @keyframes starDriftFar {
+      from { transform: translate3d(0,0,0); }
+      to { transform: translate3d(-30px,30px,0); }
+    }
+    @keyframes starDriftMid {
+      from { transform: translate3d(0,0,0); }
+      to { transform: translate3d(-60px,60px,0); }
+    }
+    @keyframes starDriftNear {
+      from { transform: translate3d(0,0,0); }
+      to { transform: translate3d(-90px,90px,0); }
     }
     @keyframes starTwinkle {
       0%,100% { opacity: .4; }
       50% { opacity: .8; }
     }
-    .stars {
-      position: fixed; inset: 0; pointer-events:none; opacity:.6;
+    .stars, .stars-far, .stars-near {
+      position: fixed; inset: -50px; pointer-events:none;
       background-image:
         radial-gradient(2px 2px at 20% 30%, rgba(255,255,255,.9), rgba(255,255,255,0)),
         radial-gradient(1.5px 1.5px at 70% 20%, rgba(255,255,255,.7), rgba(255,255,255,0)),
@@ -45,8 +53,11 @@
         radial-gradient(2px 2px at 85% 60%, rgba(255,255,255,.8), rgba(255,255,255,0));
       background-repeat: repeat;
       background-size: 200% 200%;
-      animation: starMove 200s linear infinite, starTwinkle 5s ease-in-out infinite;
+      will-change: transform;
     }
+    .stars-far { opacity:.3; animation: starDriftFar 20s linear infinite, starTwinkle 5s ease-in-out infinite; }
+    .stars { opacity:.5; animation: starDriftMid 15s linear infinite, starTwinkle 5s ease-in-out infinite; }
+    .stars-near { opacity:.8; animation: starDriftNear 10s linear infinite, starTwinkle 5s ease-in-out infinite; }
     .ufo {
       position: fixed; top: 25%; left: -100px; font-size: 32px; opacity: 0; pointer-events: none;
       filter: drop-shadow(0 0 6px var(--accent));
@@ -59,19 +70,46 @@
     .container { position: relative; z-index: 1; max-width: 960px; margin: 0 auto; padding: 24px; text-align: center; }
     h1 { letter-spacing: .35em; text-transform: uppercase; }
     .pill { border: 1px solid #ffffff1a; padding: 10px 14px; border-radius: 12px; background: #00000066; display: inline-block; margin: 4px; text-transform: uppercase; letter-spacing: .2em; font-size: 12px;}
-    .btn { border: none; padding: 18px 24px; font-weight: 800; border-radius: 18px; cursor: pointer; background: var(--accent); color: #000; text-transform: uppercase; letter-spacing: .25em; transition: transform .1s, box-shadow .3s; }
+    .btn { border: none; padding: 18px 24px; font-weight: 800; border-radius: 18px; cursor: pointer; background: var(--accent); color: #000; text-transform: uppercase; letter-spacing: .25em; transition: transform 120ms, box-shadow 200ms; }
     .btn:hover:not([disabled]) { transform: translateY(-2px); box-shadow: 0 0 8px var(--accent); }
     .btn:active { transform: translateY(1px); }
     .btn[disabled] { opacity: .4; cursor: not-allowed; }
     .btn-outline { background: transparent; border: 1px solid #ffffff99; color: #fff; }
     .grid { display: grid; gap: 12px; }
     @media(min-width: 768px){ .grid.cols-2{ grid-template-columns: repeat(2, 1fr);} .grid.cols-3{ grid-template-columns: repeat(3, 1fr);} }
-    .card { background: #00000080; border: 1px solid #ffffff1a; border-radius: 16px; text-align: left; }
+    .card { background: #00000080; border: 1px solid #ffffff1a; border-radius: 16px; text-align: left; transition: transform 120ms, box-shadow 200ms; }
+    .card:hover { transform: translateY(-2px); box-shadow: 0 0 8px var(--accent); }
+    .card.disabled { opacity:.4; cursor:not-allowed; }
+    .card.disabled:hover { transform:none; box-shadow:none; }
     .card .content { padding: 16px; }
     .section-title { margin: 32px 0 12px; display:flex; align-items:center; justify-content:center; gap:12px; }
     .section-title .dot { width: 12px; height: 12px; background: #fff; }
     .progress { height: 8px; background: #ffffff1a; border-radius: 4px; overflow: hidden; }
-    .progress > span { display:block; height:100%; background: #fff; }
+    .progress > .fill { display:block; height:100%; background: linear-gradient(90deg, var(--accent), #fff); }
+    .progress > .fill.striped {
+      background:
+        linear-gradient(90deg, var(--accent), #fff),
+        repeating-linear-gradient(45deg, rgba(255,255,255,.3) 0 10px, rgba(255,255,255,0) 10px 20px);
+      background-size:100% 100%,20px 20px;
+      animation: stripeMove 6s linear infinite;
+    }
+    @keyframes stripeMove { from { background-position:0 0,0 0; } to { background-position:0 0,40px 0; } }
+    #harvest-btn { transition: transform 120ms, box-shadow 200ms; }
+    #harvest-btn:active { transform: scale(0.95); }
+    #harvest-btn.is-holding { animation: pulseGlow 1s ease-in-out infinite; }
+    @keyframes pulseGlow {
+      0%,100% { box-shadow:0 0 0 var(--accent); transform:scale(1); }
+      50% { box-shadow:0 0 12px var(--accent); transform:scale(1.03); }
+    }
+    #particles { position: fixed; inset:0; pointer-events:none; }
+    .particle { position:absolute; width:4px; height:4px; background:var(--accent); border-radius:50%; animation: particleMove var(--dur) ease-out forwards; }
+    @keyframes particleMove { to { transform: translate(var(--tx), var(--ty)); opacity:0; } }
+    .badge { background:#ffffff33; padding:2px 6px; border-radius:6px; font-size:12px; display:inline-block; }
+    .badge.flash { animation: badgeFlash 200ms ease-out; background:var(--accent); color:#000; }
+    @keyframes badgeFlash { to { background:#ffffff33; color:#fff; } }
+    @media (prefers-reduced-motion: reduce) {
+      .bg-gradient, .stars, .stars-far, .stars-near, #harvest-btn.is-holding, .progress > .fill.striped { animation:none; }
+    }
     @media(max-width:480px){
       h1{ font-size:1.6rem; letter-spacing:.2em; }
       .pill{ font-size:10px; padding:8px 10px; }
@@ -81,9 +119,12 @@
 </head>
 <body>
   <div class="bg-gradient"></div>
+  <div class="stars-far"></div>
   <div class="stars"></div>
+  <div class="stars-near"></div>
   <div id="ufo" class="ufo">🛸</div>
   <div id="root"></div>
+  <div id="particles"></div>
 
   <!-- React & Babel CDN (no build step) -->
   <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>


### PR DESCRIPTION
## Summary
- Layered parallax starfield with far and near layers that respect reduced motion preferences
- Harvest button gets pulse/glow on hold and spawns floating energy particles on tap
- Smooth energy counter tween and upgrade card hover/disabled feedback with flashing owned badge
- Prestige progress bar now shows animated gradient stripes, respecting reduced motion

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68af7b7b8d948328a87196ca4dded9c3