### PR TITLE
Add night sky backdrop and harvest feedback

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,22 @@ const computeCost=(b,s,o)=>Math.floor(b*Math.pow(s,o));
 const prestigeGain=(e)=>Math.floor(Math.sqrt(e/50000));
 const HOLD_INTERVAL_MS=60;
 
+function spawnParticles(x,y,count=6){
+  const container=document.getElementById("particles");
+  if(!container) return;
+  const MAX_CHILDREN=80;
+  if(container.childElementCount>MAX_CHILDREN) return;
+  for(let i=0;i<count;i++){
+    const el=document.createElement("span");
+    el.className="particle";
+    el.style.left=(x+(Math.random()*40-20))+"px";
+    el.style.top=(y+(Math.random()*20-10))+"px";
+    el.style.animationDuration=(400+Math.random()*300)+"ms";
+    container.appendChild(el);
+    el.addEventListener("animationend",()=>el.remove());
+  }
+}
+
 // DATA
 const UPGRADES=[
   {id:"alien-tech",title:"ALIEN TECH UPGRADE",subtitle:"+1 ENERGY PER TAP",type:"click",baseCost:50,costScale:1.22,amountPerBuy:1},
@@ -26,13 +42,17 @@ const CONTRACTS=[
 
 function SectionTitle({children}){ return <div className="section-title"><div className="dot"></div><h2>{children}</h2></div>; }
 function Pill({children}){ return <div className="pill">{children}</div>; }
-function ProgressBar({value}){ const v=Math.max(0,Math.min(100,value||0)); return <div className="progress"><span style={{width:v+"%"}}/></div>; }
+function ProgressBar({value}){ const v=Math.max(0,Math.min(100,value||0)); const striped=v>0&&v<100; return <div className="progress"><span className={`fill${striped?" striped":""}`} style={{width:v+"%"}}/></div>; }
 
 function App(){
   const [energy,setEnergy]=useState(0),[clickPower,setClickPower]=useState(1),[autoPerSec,setAutoPerSec]=useState(0),[mult,setMult]=useState(1),[owned,setOwned]=useState({}),[rp,setRp]=useState(0),[prestiges,setPrestiges]=useState(0);
   const [research,setResearch]=useState({tapBoost:0,autoBoost:0,multBoost:0});
   const [completedContracts,setCompletedContracts]=useState([]);
+  const [displayEnergy,setDisplayEnergy]=useState(0);
   const holdRef = useRef(null);
+  const animRef = useRef(null);
+  const btnRef = useRef(null);
+  const badgeRefs = useRef({});
 
   // self-tests (console)
   useEffect(()=>{try{
@@ -52,6 +72,24 @@ function App(){
     }catch(e){} } },[]);
   useEffect(()=>{ localStorage.setItem("area52-pwa-save-v2", JSON.stringify({energy,clickPower,autoPerSec,mult,owned,rp,prestiges,research,completedContracts})); },
     [energy,clickPower,autoPerSec,mult,owned,rp,prestiges,research,completedContracts]);
+  useEffect(()=>{
+    const from=displayEnergy;
+    const to=energy;
+    if(from===to) return;
+    cancelAnimationFrame(animRef.current);
+    const diff=to-from;
+    if(Math.abs(diff)<5){ setDisplayEnergy(to); return; }
+    const duration=Math.min(240,Math.max(120,Math.abs(diff)));
+    const start=performance.now();
+    const step=(now)=>{
+      const p=Math.min(1,(now-start)/duration);
+      const eased=1-Math.pow(1-p,3);
+      setDisplayEnergy(from+diff*eased);
+      if(p<1) animRef.current=requestAnimationFrame(step);
+    };
+    animRef.current=requestAnimationFrame(step);
+  },[energy]);
+  useEffect(()=>()=>cancelAnimationFrame(animRef.current),[]);
 
   // passive income
   useEffect(()=>{ const t=setInterval(()=>{ setEnergy(e=>e+Math.floor(autoPerSec*(1+research.autoBoost)*(1+rp*0.02+research.multBoost+(mult-1)))) },1000);
@@ -59,11 +97,28 @@ function App(){
   },[autoPerSec,mult,rp,research]);
 
   const totalMult=useMemo(()=>1+rp*0.02+research.multBoost+(mult-1),[rp,mult,research]);
-  const handleTap=()=>setEnergy(e=>e+Math.floor(clickPower*(1+research.tapBoost)*totalMult));
+  const handleTap=(e)=>{
+    setEnergy(prev=>prev+Math.floor(clickPower*(1+research.tapBoost)*totalMult));
+    const rect=e?.currentTarget?.getBoundingClientRect?.()||e?.target?.getBoundingClientRect?.();
+    if(rect){
+      spawnParticles(rect.left+rect.width/2, rect.top+rect.height/2-8, 6);
+    }
+  };
 
   // hold-to-tap
-  const startHold=(ev)=>{ev?.preventDefault?.(); if(holdRef.current) return; holdRef.current=setInterval(()=>handleTap(),HOLD_INTERVAL_MS)};
-  const stopHold=()=>{if(holdRef.current){clearInterval(holdRef.current); holdRef.current=null;}};
+  const startHold=(ev)=>{
+    ev?.preventDefault?.();
+    if(holdRef.current) return;
+    btnRef.current?.classList.add('is-holding');
+    holdRef.current=setInterval(()=>handleTap(ev),HOLD_INTERVAL_MS);
+  };
+  const stopHold=()=>{
+    if(holdRef.current){
+      clearInterval(holdRef.current);
+      holdRef.current=null;
+    }
+    btnRef.current?.classList.remove('is-holding');
+  };
 
   const getOwned=(id)=>owned[id]||0;
   const costOf=(u)=>computeCost(u.baseCost,u.costScale,getOwned(u.id));
@@ -72,6 +127,8 @@ function App(){
     if(u.type==="click")setClickPower(v=>v+u.amountPerBuy);
     if(u.type==="auto")setAutoPerSec(v=>v+u.amountPerBuy);
     if(u.type==="mult")setMult(v=>v+u.amountPerBuy);
+    const b=badgeRefs.current[u.id];
+    if(b){ b.classList.add('flash'); b.addEventListener('animationend',()=>b.classList.remove('flash'),{once:true}); }
   };
 
   const canPrestige=energy>=50000;
@@ -94,39 +151,46 @@ function App(){
         Tap to gather alien energy, fund secret experiments and unlock forbidden tech.
       </p>
 
-      <div style={{marginTop:18, display:"flex", flexWrap:"wrap", gap:12, justifyContent:"center"}}>
-        <button className="btn"
-          onClick={handleTap}
-          onMouseDown={startHold} onMouseUp={stopHold} onMouseLeave={stopHold}
-          onTouchStart={startHold} onTouchEnd={stopHold}
+      <div style={{marginTop:18, display:"grid", gap:12, justifyItems:"center"}}>
+        {/* BIG ENERGY ABOVE BUTTON */}
+        <div className="energy-big" style={{color: ACCENT}}>
+          {fmt(Math.floor(displayEnergy ?? energy))}
+          <span className="energy-unit">ENERGY</span>
+        </div>
+
+        <button id="harvest-btn" ref={btnRef} className="btn"
+          onClick={(e)=>handleTap(e)}
+          onMouseDown={(e)=>startHold(e)} onMouseUp={stopHold} onMouseLeave={stopHold}
+          onTouchStart={(e)=>startHold(e)} onTouchEnd={stopHold}
         >👽 Harvest Energy</button>
 
-        <Pill>Energy: <span style={{color:ACCENT, marginLeft:8}}>{fmt(energy)}</span></Pill>
-        <Pill>Click Power: <span style={{color:ACCENT, marginLeft:8}}>{fmt(clickPower)}×</span></Pill>
-        <Pill>Auto/sec: <span style={{color:ACCENT, marginLeft:8}}>{fmt(Math.floor(autoPerSec*totalMult))}</span></Pill>
-        <Pill>Global Mult: <span style={{color:ACCENT, marginLeft:8}}>{totalMult.toFixed(2)}×</span></Pill>
+        <div style={{display:"flex", flexWrap:"wrap", gap:12, justifyContent:"center"}}>
+          <Pill>Click Power: <span style={{color:ACCENT, marginLeft:8}}>{fmt(clickPower)}×</span></Pill>
+          <Pill>Auto/sec: <span style={{color:ACCENT, marginLeft:8}}>{fmt(Math.floor(autoPerSec*totalMult))}</span></Pill>
+          <Pill>Global Mult: <span style={{color:ACCENT, marginLeft:8}}>{totalMult.toFixed(2)}×</span></Pill>
+        </div>
       </div>
 
       {/* Upgrades close to main button */}
       <SectionTitle>UPGRADES</SectionTitle>
       <div className="grid cols-3">
-        {UPGRADES.map(u=>(
-          <div key={u.id} className="card">
+        {UPGRADES.map(u=>{ const cost=costOf(u); const can=energy>=cost; return (
+          <div key={u.id} className={`card${can?"":" disabled"}`}>
             <div className="content">
               <div style={{display:"flex", justifyContent:"space-between", alignItems:"flex-start"}}>
                 <div>
                   <div style={{letterSpacing:".25em", textTransform:"uppercase", fontSize:14}}>{u.title}</div>
                   <div style={{opacity:.7, fontSize:12}}>{u.subtitle}</div>
                 </div>
-                <span className="badge">Owned: {getOwned(u.id)}</span>
+                <span ref={el=>badgeRefs.current[u.id]=el} className="badge">Owned: {getOwned(u.id)}</span>
               </div>
               <div style={{display:"flex", justifyContent:"space-between", alignItems:"center", marginTop:12}}>
-                <div style={{opacity:.8, fontSize:14}}>Cost: <span style={{color:ACCENT}}>{fmt(costOf(u))}</span></div>
-                <button className="btn btn-outline" disabled={energy<costOf(u)} onClick={()=>buy(u)}>Add — {fmt(costOf(u))}</button>
+                <div style={{opacity:.8, fontSize:14}}>Cost: <span style={{color:ACCENT}}>{fmt(cost)}</span></div>
+                <button className="btn btn-outline" disabled={!can} onClick={()=>buy(u)}>Add — {fmt(cost)}</button>
               </div>
             </div>
           </div>
-        ))}
+        );})}
       </div>
 
       {/* Prestige */}
@@ -139,7 +203,7 @@ function App(){
           </div>
           <div style={{marginTop:8, opacity:.8, fontSize:14}}>Reset and trade built-up Energy for <b>Research Points</b> that permanently boost all gains.</div>
           <div style={{marginTop:12}}><ProgressBar value={progressToPrestige} /></div>
-          <div style={{marginTop:6, opacity:.7, fontSize:12}}>Next RP at <span style={{color:ACCENT}}>50,000</span> energy. Current: {fmt(energy)}</div>
+          <div style={{marginTop:6, opacity:.7, fontSize:12}}>Next RP at <span style={{color:ACCENT}}>50,000</span> energy. Current: {fmt(Math.floor(displayEnergy))}</div>
           <div style={{marginTop:12}}>
             <button className="btn btn-outline" disabled={!canPrestige} onClick={doPrestige}>Declassify now</button>
           </div>

--- a/index.html
+++ b/index.html
@@ -9,59 +9,48 @@
   <style>
     :root {
       --accent: #B9FF3F;
-      --bg0: #140106; --bg1: #3b0613; --bg2: #7a0a23; --bg3: #b21438;
+      /* Night sky palette */
+      --sky0: #000000;
+      --sky1: #02040F;
+      --sky2: #0A1326;
     }
     html, body, #root { height: 100%; margin: 0; }
     body {
-      background: linear-gradient(180deg, var(--bg1), var(--bg0));
+      background: linear-gradient(180deg, var(--sky2), var(--sky1), var(--sky0));
       color: #fff;
       font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     }
-    @keyframes gradientShift {
-      0%,100% { background-position: 0 0, 0 0, 0 0; }
-      50% { background-position: 10% -10%, -10% 5%, 0 0; }
+    .bg-gradient {
+      position: fixed; inset: 0; pointer-events: none; opacity: 1;
+      background: radial-gradient(1200px 800px at 50% -20%, rgba(10,19,38,0.6), transparent 60%),
+                  radial-gradient(1000px 600px at 80% 10%, rgba(10,19,38,0.4), transparent 55%),
+                  linear-gradient(180deg, var(--sky2), var(--sky1), var(--sky0));
+      animation: none; /* no parallax */
     }
-    .bg-gradient { position: fixed; inset: 0; pointer-events: none; opacity: .9;
-      background:
-        radial-gradient(1200px 800px at 120% -20%, var(--bg3), transparent 60%),
-        radial-gradient(1000px 600px at -20% 10%, var(--bg2), transparent 55%),
-        linear-gradient(180deg, var(--bg1), var(--bg0));
-      animation: gradientShift 30s ease-in-out infinite;
-    }
-    @keyframes starMove {
-      from { background-position: 0 0; }
-      to { background-position: -1000px 1000px; }
-    }
-    @keyframes starTwinkle {
-      0%,100% { opacity: .4; }
-      50% { opacity: .8; }
-    }
+
+    /* Stars: many points, subtle twinkle (no movement) */
     .stars {
-      position: fixed; inset: 0; pointer-events:none; opacity:.6;
+      position: fixed; inset: -50px; pointer-events:none;
       background-image:
-        radial-gradient(2px 2px at 20% 30%, rgba(255,255,255,.9), rgba(255,255,255,0)),
-        radial-gradient(1.5px 1.5px at 70% 20%, rgba(255,255,255,.7), rgba(255,255,255,0)),
-        radial-gradient(1.2px 1.2px at 40% 70%, rgba(255,255,255,.6), rgba(255,255,255,0)),
-        radial-gradient(2px 2px at 85% 60%, rgba(255,255,255,.8), rgba(255,255,255,0));
+        radial-gradient(1px 1px at 10% 20%, rgba(255,255,255,.9), rgba(255,255,255,0)),
+        radial-gradient(1px 1px at 20% 80%, rgba(255,255,255,.9), rgba(255,255,255,0)),
+        radial-gradient(1.2px 1.2px at 35% 30%, rgba(255,255,255,.85), rgba(255,255,255,0)),
+        radial-gradient(1.2px 1.2px at 50% 60%, rgba(255,255,255,.85), rgba(255,255,255,0)),
+        radial-gradient(1.4px 1.4px at 70% 40%, rgba(255,255,255,.8), rgba(255,255,255,0)),
+        radial-gradient(1.4px 1.4px at 85% 70%, rgba(255,255,255,.8), rgba(255,255,255,0)),
+        radial-gradient(2px 2px at 30% 50%, rgba(255,255,255,.9), rgba(255,255,255,0)),
+        radial-gradient(2px 2px at 65% 20%, rgba(255,255,255,.9), rgba(255,255,255,0));
       background-repeat: repeat;
       background-size: 200% 200%;
-      animation: starMove 200s linear infinite, starTwinkle 5s ease-in-out infinite;
+      opacity:.9;
+      animation: starTwinkle 6s ease-in-out infinite;
     }
-    .ufo {
-      position: fixed; top: 25%; left: -100px; font-size: 32px; opacity: 0; pointer-events: none;
-      filter: drop-shadow(0 0 6px var(--accent));
-    }
-    .ufo.flying { animation: fly 12s linear forwards; }
-    @keyframes fly {
-      from { transform: translateX(0); }
-      to { transform: translateX(calc(100vw + 200px)); }
-    }
+    @keyframes starTwinkle { 0%,100%{opacity:.6} 50%{opacity:.9} }
+
     .container { position: relative; z-index: 1; max-width: 960px; margin: 0 auto; padding: 24px; text-align: center; }
     h1 { letter-spacing: .35em; text-transform: uppercase; }
     .pill { border: 1px solid #ffffff1a; padding: 10px 14px; border-radius: 12px; background: #00000066; display: inline-block; margin: 4px; text-transform: uppercase; letter-spacing: .2em; font-size: 12px;}
-    .btn { border: none; padding: 18px 24px; font-weight: 800; border-radius: 18px; cursor: pointer; background: var(--accent); color: #000; text-transform: uppercase; letter-spacing: .25em; transition: transform .1s, box-shadow .3s; }
-    .btn:hover:not([disabled]) { transform: translateY(-2px); box-shadow: 0 0 8px var(--accent); }
-    .btn:active { transform: translateY(1px); }
+    .btn { border: none; padding: 18px 24px; font-weight: 800; border-radius: 18px; cursor: pointer; background: var(--accent); color: #000; text-transform: uppercase; letter-spacing: .25em; }
     .btn[disabled] { opacity: .4; cursor: not-allowed; }
     .btn-outline { background: transparent; border: 1px solid #ffffff99; color: #fff; }
     .grid { display: grid; gap: 12px; }
@@ -72,6 +61,44 @@
     .section-title .dot { width: 12px; height: 12px; background: #fff; }
     .progress { height: 8px; background: #ffffff1a; border-radius: 4px; overflow: hidden; }
     .progress > span { display:block; height:100%; background: #fff; }
+
+    /* BIG ENERGY (now above the button) */
+    .energy-big {
+      font-weight: 900;
+      letter-spacing: .06em;
+      font-size: clamp(28px, 6vw, 56px);
+      line-height: 1.1;
+      margin: 6px 0 0;
+    }
+    .energy-unit { font-size: 0.5em; opacity: .8; margin-left: .4em; }
+
+    /* Button micro-interactions */
+    .btn:active { transform: scale(0.96); }
+    .btn.is-holding {
+      animation: pulseGlow 1s infinite;
+    }
+    @keyframes pulseGlow {
+      0%   { box-shadow: 0 0 0px var(--accent); transform: scale(1.00); }
+      50%  { box-shadow: 0 0 18px var(--accent); transform: scale(1.03); }
+      100% { box-shadow: 0 0 0px var(--accent); transform: scale(1.00); }
+    }
+
+    /* Energy particles */
+    #particles { position:fixed; inset:0; pointer-events:none; overflow:hidden; z-index: 2; }
+    .particle {
+      position:absolute; width:6px; height:6px; border-radius:50%;
+      background: var(--accent); opacity:1;
+      animation: rise 600ms forwards;
+    }
+    @keyframes rise {
+      from { transform: translateY(0) scale(1); opacity:1; }
+      to   { transform: translateY(-80px) scale(0.5); opacity:0; }
+    }
+
+    /* Respect reduced motion */
+    @media (prefers-reduced-motion: reduce) {
+      * { animation: none !important; transition: none !important; }
+    }
     @media(max-width:480px){
       h1{ font-size:1.6rem; letter-spacing:.2em; }
       .pill{ font-size:10px; padding:8px 10px; }
@@ -82,7 +109,7 @@
 <body>
   <div class="bg-gradient"></div>
   <div class="stars"></div>
-  <div id="ufo" class="ufo">🛸</div>
+  <div id="particles"></div>
   <div id="root"></div>
 
   <!-- React & Babel CDN (no build step) -->
@@ -96,17 +123,6 @@
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker.register('sw.js');
     }
-  </script>
-  <script>
-    const ufoEl = document.getElementById('ufo');
-    function launchUfo(){
-      if(ufoEl.classList.contains('flying')) return;
-      ufoEl.classList.add('flying');
-      ufoEl.addEventListener('animationend', () => {
-        ufoEl.classList.remove('flying');
-      }, {once:true});
-    }
-    setInterval(() => { if(Math.random() < 0.01) launchUfo(); }, 10000);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace parallax red background with static night sky and twinkling stars
- Move energy tally above the harvest button and add hold pulse feedback
- Spawn accent-colored energy particles on taps with automatic cleanup

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68af7b7b8d948328a87196ca4dded9c3