### PR TITLE
feat: add layered twinkling starfield

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,9 +28,40 @@
                   linear-gradient(180deg, var(--sky2), var(--sky1), var(--sky0));
       animation: none;
     }
-    /* Single rich star layer with subtle twinkle */
-    .stars {
-      position: fixed; inset: -50px; pointer-events:none;
+    /* Layered star field with subtle twinkle */
+    .stars-back,
+    .stars-mid,
+    .stars-front {
+      position: fixed;
+      inset: -50px;
+      pointer-events: none;
+      background-repeat: repeat;
+      animation: starTwinkle 6s ease-in-out infinite;
+    }
+
+    .stars-back {
+      background-image:
+        radial-gradient(1px 1px at 10% 20%, rgba(255,255,255,.9), rgba(255,255,255,0)),
+        radial-gradient(1px 1px at 20% 80%, rgba(255,255,255,.9), rgba(255,255,255,0)),
+        radial-gradient(1.2px 1.2px at 35% 30%, rgba(255,255,255,.85), rgba(255,255,255,0)),
+        radial-gradient(1.2px 1.2px at 50% 60%, rgba(255,255,255,.85), rgba(255,255,255,0));
+      background-size: 400% 400%;
+      opacity: .3;
+    }
+
+    .stars-mid {
+      background-image:
+        radial-gradient(1px 1px at 10% 20%, rgba(255,255,255,.9), rgba(255,255,255,0)),
+        radial-gradient(1px 1px at 20% 80%, rgba(255,255,255,.9), rgba(255,255,255,0)),
+        radial-gradient(1.2px 1.2px at 35% 30%, rgba(255,255,255,.85), rgba(255,255,255,0)),
+        radial-gradient(1.2px 1.2px at 50% 60%, rgba(255,255,255,.85), rgba(255,255,255,0)),
+        radial-gradient(1.4px 1.4px at 70% 40%, rgba(255,255,255,.8), rgba(255,255,255,0)),
+        radial-gradient(1.4px 1.4px at 85% 70%, rgba(255,255,255,.8), rgba(255,255,255,0));
+      background-size: 300% 300%;
+      opacity: .6;
+    }
+
+    .stars-front {
       background-image:
         radial-gradient(1px 1px at 10% 20%, rgba(255,255,255,.9), rgba(255,255,255,0)),
         radial-gradient(1px 1px at 20% 80%, rgba(255,255,255,.9), rgba(255,255,255,0)),
@@ -40,10 +71,8 @@
         radial-gradient(1.4px 1.4px at 85% 70%, rgba(255,255,255,.8), rgba(255,255,255,0)),
         radial-gradient(2px 2px at 30% 50%, rgba(255,255,255,.9), rgba(255,255,255,0)),
         radial-gradient(2px 2px at 65% 20%, rgba(255,255,255,.9), rgba(255,255,255,0));
-      background-repeat: repeat;
       background-size: 200% 200%;
-      opacity:.9;
-      animation: starTwinkle 6s ease-in-out infinite;
+      opacity: .9;
     }
     @keyframes starTwinkle { 0%,100%{opacity:.6} 50%{opacity:.9} }
 
@@ -122,7 +151,9 @@
 </head>
 <body>
   <div class="bg-gradient"></div>
-  <div class="stars"></div>
+  <div class="stars-back"></div>
+  <div class="stars-mid"></div>
+  <div class="stars-front"></div>
   <div id="particles"></div>
   <div id="root"></div>
   <button id="update-btn" class="btn btn-outline update-btn">Update</button>


### PR DESCRIPTION
## Summary
- split single star layer into back, mid, front layers with varied densities and opacity
- apply existing starTwinkle animation to each layer
- render three star divs instead of one

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b03e2bdf408328ac7a70d396fcdac8