### PR TITLE
feat: show big energy number above harvest button

### DIFF
--- a/app.js
+++ b/app.js
@@ -138,17 +138,19 @@ function App(){
         Tap to gather alien energy, fund secret experiments and unlock forbidden tech.
       </p>
 
-      <div style={{marginTop:18, display:"flex", flexWrap:"wrap", gap:12, justifyContent:"center"}}>
+      <div className="harvest-zone" style={{marginTop:18, display:"flex", flexDirection:"column", alignItems:"center", gap:12}}>
+        <div className="energy-big">{fmt(Math.floor(displayEnergy))}<span className="energy-unit">E</span></div>
         <button id="harvest-btn" ref={btnRef} className="btn"
           onClick={handleTap}
           onMouseDown={startHold} onMouseUp={stopHold} onMouseLeave={stopHold}
           onTouchStart={startHold} onTouchEnd={stopHold}
         >👽 Harvest Energy</button>
 
-        <Pill>Energy: <span style={{color:ACCENT, marginLeft:8}}>{fmt(Math.floor(displayEnergy))}</span></Pill>
-        <Pill>Click Power: <span style={{color:ACCENT, marginLeft:8}}>{fmt(clickPower)}×</span></Pill>
-        <Pill>Auto/sec: <span style={{color:ACCENT, marginLeft:8}}>{fmt(Math.floor(autoPerSec*totalMult))}</span></Pill>
-        <Pill>Global Mult: <span style={{color:ACCENT, marginLeft:8}}>{totalMult.toFixed(2)}×</span></Pill>
+        <div style={{display:"flex", flexWrap:"wrap", gap:12, justifyContent:"center"}}>
+          <Pill>Click Power: <span style={{color:ACCENT, marginLeft:8}}>{fmt(clickPower)}×</span></Pill>
+          <Pill>Auto/sec: <span style={{color:ACCENT, marginLeft:8}}>{fmt(Math.floor(autoPerSec*totalMult))}</span></Pill>
+          <Pill>Global Mult: <span style={{color:ACCENT, marginLeft:8}}>{totalMult.toFixed(2)}×</span></Pill>
+        </div>
       </div>
 
       {/* Upgrades close to main button */}

--- a/index.html
+++ b/index.html
@@ -77,14 +77,16 @@
     @keyframes stripeMove { from{background-position:0 0,0 0;} to{background-position:200% 0,40px 0;} }
 
     /* BIG ENERGY (above button) */
-    .energy-big {
-      font-weight: 900;
-      letter-spacing: .06em;
-      font-size: clamp(28px, 6vw, 56px);
-      line-height: 1.1;
-      margin: 6px 0 0;
-    }
-    .energy-unit { font-size: 0.5em; opacity: .8; margin-left: .4em; }
+      .energy-big {
+        font-weight: 900;
+        letter-spacing: .06em;
+        font-size: clamp(28px, 6vw, 56px);
+        line-height: 1.1;
+        margin: 6px 0 0;
+        color: var(--accent);
+        text-shadow: 0 0 12px var(--accent);
+      }
+      .energy-unit { font-size: 0.5em; opacity: .8; margin-left: .4em; }
 
     /* Button micro-interactions */
     .btn:active { transform: scale(0.96); }


### PR DESCRIPTION
## Summary
- Display energy in a glowing `.energy-big` element above the harvest button.
- Wrap harvest controls in a new `harvest-zone` container and remove old energy pill.
- Style `.energy-big` with accent color and glow effect.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b042310e648328842c23c671dcb51b