### PR TITLE
Enhance harvest button with glow and spotlight

### DIFF
--- a/app.js
+++ b/app.js
@@ -139,6 +139,7 @@ function App(){
       </p>
 
       <div className="harvest-zone" style={{marginTop:18, display:"flex", flexDirection:"column", alignItems:"center", gap:12}}>
+        <div className="spotlight"></div>
         <div className="energy-big">{fmt(Math.floor(displayEnergy))}<span className="energy-unit">E</span></div>
         <button id="harvest-btn" ref={btnRef} className="btn"
           onClick={handleTap}

--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@
     .pill { border: 1px solid #ffffff1a; padding: 10px 14px; border-radius: 12px; background: #00000066; display: inline-block; margin: 4px; text-transform: uppercase; letter-spacing: .2em; font-size: 12px;}
     .btn { border: none; padding: 18px 24px; font-weight: 800; border-radius: 18px; cursor: pointer; background: var(--accent); color: #000; text-transform: uppercase; letter-spacing: .25em; transition: transform 120ms, box-shadow 200ms; }
     .btn[disabled] { opacity: .4; cursor: not-allowed; }
+    #harvest-btn { padding: 24px 32px; font-size: 18px; animation: idleGlow 3s ease-in-out infinite; }
     .btn-outline { background: transparent; border: 1px solid #ffffff99; color: #fff; }
     .update-btn { position:fixed; top:8px; right:8px; z-index:3; padding:8px 12px; font-size:10px; letter-spacing:.2em; }
     .grid { display: grid; gap: 12px; }
@@ -117,12 +118,20 @@
       }
       .energy-unit { font-size: 0.5em; opacity: .8; margin-left: .4em; }
 
+    .harvest-zone { position: relative; }
+    .spotlight { position: absolute; top:50%; left:50%; transform: translate(-50%,-50%); width:260px; height:260px; background: radial-gradient(circle, rgba(185,255,63,0.15), rgba(185,255,63,0) 70%); z-index: -1; pointer-events:none; }
+
     /* Button micro-interactions */
     .btn:active { transform: scale(0.96); }
     .btn.is-holding { animation: pulseGlow 1s infinite; }
+    @keyframes idleGlow {
+      0%   { box-shadow: 0 0 6px var(--accent); }
+      50%  { box-shadow: 0 0 12px var(--accent); }
+      100% { box-shadow: 0 0 6px var(--accent); }
+    }
     @keyframes pulseGlow {
       0%   { box-shadow: 0 0 0px var(--accent); transform: scale(1.00); }
-      50%  { box-shadow: 0 0 18px var(--accent); transform: scale(1.03); }
+      50%  { box-shadow: 0 0 36px var(--accent); transform: scale(1.03); }
       100% { box-shadow: 0 0 0px var(--accent); transform: scale(1.00); }
     }
 
@@ -148,6 +157,7 @@
       h1{ font-size:1.6rem; letter-spacing:.2em; }
       .pill{ font-size:10px; padding:8px 10px; }
       .btn{ font-size:12px; padding:14px 18px; letter-spacing:.2em; }
+      #harvest-btn{ font-size:14px; padding:18px 24px; }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- Enlarge harvest button and add idle glow animation
- Strengthen hold pulse and style spotlight framing harvest zone
- Insert spotlight div behind energy display and button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b04e63b6f88328a51039707045c049