### PR TITLE
Add milestone visual progress wrapper

### DIFF
--- a/app.js
+++ b/app.js
@@ -95,6 +95,13 @@ function App(){
     if(newlyUnlocked.length) setUnlockedParts(p=>[...p,...newlyUnlocked]);
   },[energy,unlockedParts]);
 
+  useEffect(()=>{
+    unlockedParts.forEach(id=>{
+      const el=document.getElementById(id);
+      if(el) el.classList.remove('hidden');
+    });
+  },[unlockedParts]);
+
   const totalMult=useMemo(()=>1+rp*0.02+research.multBoost+(mult-1),[rp,mult,research]);
   const spawnParticles=()=>{
     const layer=particleLayerRef.current,btn=btnRef.current; if(!layer||!btn) return;

--- a/index.html
+++ b/index.html
@@ -159,6 +159,11 @@
       .btn{ font-size:12px; padding:14px 18px; letter-spacing:.2em; }
       #harvest-btn{ font-size:14px; padding:18px 24px; }
     }
+
+    /* Visual milestone progress */
+    #visual-progress{ position:fixed; bottom:20px; right:20px; z-index:2; display:flex; flex-direction:column; gap:8px; align-items:center; }
+    .ufo-part{ width:80px; }
+    .hidden{ display:none; }
   </style>
 </head>
 <body>
@@ -168,6 +173,11 @@
   <div class="stars-front"></div>
   <div id="particles"></div>
   <div id="root"></div>
+  <div id="visual-progress">
+    <img id="hull" class="ufo-part hidden" src="ufo-hull.svg" alt="UFO Hull">
+    <img id="engine" class="ufo-part hidden" src="ufo-engine.svg" alt="UFO Engine">
+    <img id="bridge" class="ufo-part hidden" src="ufo-bridge.svg" alt="UFO Bridge">
+  </div>
   <button id="update-btn" class="btn btn-outline update-btn">Update</button>
 
   <!-- React & Babel CDN (no build step) -->

--- a/ufo-bridge.svg
+++ b/ufo-bridge.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <circle cx="60" cy="20" r="15" fill="#bbb" stroke="#666" stroke-width="2" />
+</svg>

--- a/ufo-engine.svg
+++ b/ufo-engine.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <rect x="35" y="20" width="50" height="20" fill="#999" stroke="#666" stroke-width="2" />
+  <polygon points="35,40 60,60 85,40" fill="#ff5722" />
+</svg>

--- a/ufo-hull.svg
+++ b/ufo-hull.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 60">
+  <ellipse cx="60" cy="30" rx="50" ry="20" fill="#ccc" stroke="#666" stroke-width="2" />
+</svg>


### PR DESCRIPTION
## Summary
- Display a new `visual-progress` wrapper in the page body for UFO build parts
- Reveal milestone parts by removing `hidden` class when unlocked
- Include placeholder SVG assets for hull, engine and bridge components

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b05e16f6848328bd640c65d8ae4432